### PR TITLE
[4단계 - Thread Pool 적용] dino.shin(신종화) 미션 제출합니다.

### DIFF
--- a/src/main/java/webserver/WebApplicationServer.java
+++ b/src/main/java/webserver/WebApplicationServer.java
@@ -1,8 +1,5 @@
 package webserver;
 
-import java.net.ServerSocket;
-import java.net.Socket;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.controller.DefaultController;
@@ -10,9 +7,19 @@ import webserver.controller.LoginController;
 import webserver.controller.RegisterController;
 import webserver.controller.UserListController;
 
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 public class WebApplicationServer {
     private static final Logger logger = LoggerFactory.getLogger(WebApplicationServer.class);
     private static final int DEFAULT_PORT = 8080;
+    private static final int CORE_POOL_SIZE = 100;
+    private static final int MAXIMUM_POOL_SIZE = 250;
+    private static final long KEEP_ALIVE_TIME = 1L;
+    private static final int WORK_QUEUE_CAPACITY = 100;
 
     public static void main(String args[]) throws Exception {
         int port = 0;
@@ -22,11 +29,14 @@ public class WebApplicationServer {
             port = Integer.parseInt(args[0]);
         }
 
-        final RequestMapping requestMapping = new RequestMapping();
-        requestMapping.add("/", new DefaultController());
-        requestMapping.add("/user/create", new RegisterController());
-        requestMapping.add("/user/login", new LoginController());
-        requestMapping.add("/user/list", new UserListController());
+        final RequestMapping requestMapping = initRequestMapping();
+        final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
+                CORE_POOL_SIZE,
+                MAXIMUM_POOL_SIZE,
+                KEEP_ALIVE_TIME,
+                TimeUnit.MINUTES,
+                new LinkedBlockingDeque<>(WORK_QUEUE_CAPACITY)
+        );
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
@@ -35,9 +45,17 @@ public class WebApplicationServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection, requestMapping));
-                thread.start();
+                threadPoolExecutor.execute(new RequestHandler(connection, requestMapping));
             }
         }
+    }
+
+    private static RequestMapping initRequestMapping() {
+        final RequestMapping requestMapping = new RequestMapping();
+        requestMapping.add("/", new DefaultController());
+        requestMapping.add("/user/create", new RegisterController());
+        requestMapping.add("/user/login", new LoginController());
+        requestMapping.add("/user/list", new UserListController());
+        return requestMapping;
     }
 }

--- a/src/main/java/webserver/response/HttpResponse.java
+++ b/src/main/java/webserver/response/HttpResponse.java
@@ -21,8 +21,9 @@ public class HttpResponse {
     private static final String CRLF = "\r\n";
     private static final String USER_LIST_PAGE_PATH = "/user/list";
     private static final String DEFAULT_FILE_NAME = "templates/index.html";
-    private static final String CONTENT_TYPE = "Content-Type: ";
-    private static final String CONTENT_LENGTH = "Content-Length: ";
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final String HEADER_DELIMITER = ": ";
     private static final String SET_COOKIE = "Set-Cookie: ";
     private static final String HTTP_1_1 = "HTTP/1.1";
     private static final String SPACE = " ";
@@ -69,8 +70,8 @@ public class HttpResponse {
 
     private void response200Header(final int lengthOfBodyContent) throws IOException {
         dos.writeBytes(HTTP_1_1 + SPACE + HttpStatusType.OK.getCode() + SPACE + HttpStatusType.OK.getCode() + CRLF);
-        dos.writeBytes(CONTENT_TYPE + header.getHeaders().getElement(CONTENT_TYPE) + CRLF);
-        dos.writeBytes(CONTENT_LENGTH + lengthOfBodyContent + CRLF);
+        dos.writeBytes(CONTENT_TYPE + HEADER_DELIMITER + header.getHeaders().getElement(CONTENT_TYPE) + CRLF);
+        dos.writeBytes(CONTENT_LENGTH + HEADER_DELIMITER + lengthOfBodyContent + CRLF);
         dos.writeBytes(CRLF);
     }
 

--- a/src/test/java/webserver/ExecutorsTest.java
+++ b/src/test/java/webserver/ExecutorsTest.java
@@ -1,21 +1,26 @@
 package webserver;
 
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StopWatch;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExecutorsTest {
     private static final Logger logger = LoggerFactory.getLogger(ExecutorsTest.class);
 
-    private static AtomicInteger counter = new AtomicInteger(0);
+    private static final AtomicInteger counter = new AtomicInteger(0);
 
     public static void main(String[] args) throws Exception {
-        ExecutorService es = Executors.newFixedThreadPool(100);
+        final ExecutorService es = Executors.newFixedThreadPool(100);
 
         StopWatch sw = new StopWatch();
         sw.start();
@@ -35,6 +40,31 @@ public class ExecutorsTest {
         es.shutdown();
         es.awaitTermination(100, TimeUnit.SECONDS);
         logger.info("Total Elaspsed: {}", sw.getTotalTimeSeconds());
+    }
+
+    @Test
+    void request_resttemplate() throws InterruptedException {
+        // given
+        final RestTemplate restTemplate = new RestTemplate();
+        final ExecutorService es = Executors.newFixedThreadPool(10);
+        final int tryCount = 250;
+
+        // when
+        IntStream.range(0, tryCount)
+                .parallel()
+                .forEach(i -> {
+                    es.execute(() -> {
+                        final int idx = counter.addAndGet(1);
+                        restTemplate.getForEntity("http://localhost:8080", String.class);
+                        logger.info("request num: {}", idx);
+                    });
+                });
+
+        es.shutdown();
+        es.awaitTermination(100, TimeUnit.SECONDS);
+
+        // then
+        assertThat(counter).hasValue(tryCount);
     }
 }
 


### PR DESCRIPTION
안녕하세요! 마지막 step에 대한 요구사항 구현했습니다.

ThreadPoolExecutor를 통해 기본 풀 사이즈는 100으로 두고, 최대 250개 까지 늘어날 수 있도록 설정했습니다.

Keep alive time은 1분으로 두어 250개까지 스레드가 늘어난 뒤 더 이상 그만큼의 요청이 없으면 추가로 생성한 150개의 스레드를 종료시키도록 했고,

250개의 스레드가 모두 사용 중인 상태에서 추가 요청이 들어올 경우 최대 100개의 요청까지 대기할 수 있도록 Work Queue Size를 100으로 설정해 보았습니다.

두 번째 요구사항의 테스트 코드는 제가 잘 이해한게 맞는지 모르겠지만, 
결국 스레드 풀 이상의 요청이 들어왔을 때 MaxSize만큼만 스레드를 생성해 사용하는지 확인하기 위한 테스트라고 생각해 최대 사이즈를 10으로 두고, 250번의 병렬 요청이 들어오도록 구성했습니다.

<img width="590" alt="image" src="https://github.com/next-step/jwp-was-kakao/assets/77482065/84ecf98d-d591-4c61-a06e-0acde28d54c4">

다음과 같이 로그를 남겨 요청이 병렬로 들어오는지 확인했고, 총 250개의 요청이 올바르게 처리되었는지도 확인해 주었습니다.

마지막 step도 잘 부탁드립니다!🙇🙇🙇🙇
